### PR TITLE
Remove extra devDependencies, add import to code examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ By default, the `AboveTheFoldOnlyServerRender` component simply returns the chil
 You can skip server side rendering by passing a skip prop:
 
 ```js
+import { AboveTheFoldOnlyServerRender } from "above-the-fold-only-server-render";
 
 const SomeComponent = () => {
   return (
@@ -43,6 +44,7 @@ const SomeComponent = () => {
 You can also skip server side rendering by setting context and passing a contextKey prop:
 
 ```js
+import { AboveTheFoldOnlyServerRender } from "above-the-fold-only-server-render";
 
 const SomeComponent = () => {
     return (

--- a/package.json
+++ b/package.json
@@ -21,10 +21,6 @@
   },
   "devDependencies": {
     "electrode-archetype-react-component": "^1.1.1",
-    "electrode-archetype-react-component-dev": "^1.1.1",
-    "electrode-demo-index": "^1.0.0",
-    "electrode-docgen": "^1.0.0",
-    "react": "^15.3.1",
-    "react-dom": "^15.3.1"
+    "electrode-archetype-react-component-dev": "^1.1.1"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,4 @@
-export { default as AboveTheFoldOnlyServerRender }
-  from "./components/above-the-fold-only-server-render";
+import AboveTheFoldOnlyServerRender from "./components/above-the-fold-only-server-render";
+
+export default AboveTheFoldOnlyServerRender;
+export { AboveTheFoldOnlyServerRender };


### PR DESCRIPTION
They'll be installed by `electrode-archetype-react-component-dev`